### PR TITLE
fix shortcuts not being handled when NumLock is active

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -210,7 +210,7 @@ int handleKeyPress(xcb_generic_event_t* event) {
 
     state = ((xcb_key_press_event_t *)event)->state;
     keycode = ((xcb_key_press_event_t *)event)->detail;
-    keysym = xcb_key_symbols_get_keysym(ksyms, keycode, state);
+    keysym = xcb_key_symbols_get_keysym(ksyms, keycode, state & XCB_MOD_MASK_SHIFT);
 
     if (keysym == XKB_KEY_Escape) { //If the keycode represents escape
         return 1;


### PR DESCRIPTION
NumLock and other modifiers alters the modifiers mask in an unwanted way, just allowing the shift modifier should fix this problem thank you @roomcays for reporting it!